### PR TITLE
Make DynamoDB table configurable for locking and remove unnecessary signal for exec

### DIFF
--- a/peridot/builder/v1/workflow/arch.go
+++ b/peridot/builder/v1/workflow/arch.go
@@ -38,7 +38,6 @@ import (
 	"fmt"
 	"github.com/google/uuid"
 	"go.temporal.io/sdk/activity"
-	"golang.org/x/sys/unix"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	"io"
 	"io/fs"
@@ -56,7 +55,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 )
 
@@ -692,9 +690,6 @@ func (c *Controller) BuildArchActivity(ctx context.Context, projectId string, pa
 	cmd := exec.Command("/bundle/fork-exec.py", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Pdeathsig: unix.SIGTERM,
-	}
 	err = cmd.Run()
 	if err != nil {
 		return fmt.Errorf("could not mock build: %v", err)

--- a/peridot/builder/v1/workflow/srpm.go
+++ b/peridot/builder/v1/workflow/srpm.go
@@ -46,7 +46,6 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/rocky-linux/srpmproc/pkg/srpmproc"
 	"go.temporal.io/sdk/activity"
-	"golang.org/x/sys/unix"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	"io"
@@ -58,7 +57,6 @@ import (
 	peridotpb "peridot.resf.org/peridot/pb"
 	"peridot.resf.org/peridot/rpmbuild"
 	"strings"
-	"syscall"
 	"time"
 )
 
@@ -448,9 +446,6 @@ func (c *Controller) BuildSRPMActivity(ctx context.Context, upstreamPrefix strin
 	cmd := exec.Command("/bundle/fork-exec.py", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Pdeathsig: unix.SIGTERM,
-	}
 	err = cmd.Run()
 	if err != nil {
 		return fmt.Errorf("could not mock build: %v", err)

--- a/peridot/builder/v1/workflow/yumrepofs.go
+++ b/peridot/builder/v1/workflow/yumrepofs.go
@@ -43,6 +43,7 @@ import (
 	"fmt"
 	"github.com/gobwas/glob"
 	"github.com/google/uuid"
+	"github.com/spf13/viper"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
@@ -518,7 +519,7 @@ func (c *Controller) UpdateRepoActivity(ctx context.Context, req *UpdateRepoRequ
 
 	lock, err := dynamolock.New(
 		c.dynamodb,
-		"peridot-repo-revision-lock",
+		viper.GetString("dynamodb-table"),
 		dynamolock.WithLeaseDuration(10*time.Second),
 		dynamolock.WithHeartbeatPeriod(3*time.Second),
 	)

--- a/peridot/cmd/v1/yumrepofsupdater/main.go
+++ b/peridot/cmd/v1/yumrepofsupdater/main.go
@@ -66,6 +66,7 @@ func init() {
 	cnf.Name = "yumrepofsupdater"
 
 	peridotcommon.AddFlags(root.PersistentFlags())
+	root.PersistentFlags().String("dynamodb-table", "peridot-repo-revision-lock", "DynamoDB table name")
 	utils.AddFlags(root.PersistentFlags(), cnf)
 }
 


### PR DESCRIPTION
Currently we have unnecessary signals for exec, and also a hardcoded DynamoDB table. This PR removes the signals and makes the table name configurable