### PR TITLE
Sync in various changes

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -82,12 +82,12 @@ go_repository(
 go_repository(
     name = "com_github_ProtonMail_go_crypto",
     importpath = "github.com/ProtonMail/go-crypto",
+    patch_args = ["-p1"],
+    patches = [
+        "//patches:0001-Key-ID-subpacket-should-not-be-hashed-or-critical-fo.patch",
+    ],
     sum = "h1:J2FzIrXN82q5uyUraeJpLIm7U6PffRwje2ORho5yIik=",
     version = "v0.0.0-20220113124808-70ae35bab23f",
-    patches = [
-      "//patches:0001-Key-ID-subpacket-should-not-be-hashed-or-critical-fo.patch",
-    ],
-    patch_args = ["-p1"],
 )
 
 go_repository(

--- a/common/frontend_server/index.mjs
+++ b/common/frontend_server/index.mjs
@@ -103,7 +103,7 @@ export default async function(opts) {
     }
 
     const config = {
-      authRequired: (process.env['DISABLE_AUTH_ENFORCE'] && process.env['DISABLE_AUTH_ENFORCE'] === 'false') || !!!opts.disableAuthEnforce,
+      authRequired: process.env['DISABLE_AUTH_ENFORCE'] ? process.env['DISABLE_AUTH_ENFORCE'] === 'false' : !!!opts.disableAuthEnforce,
       // Disable telemetry
       enableTelemetry: false,
       // Use dev secret is none is present (Prod requires a secret so not a security issue)

--- a/common/frontend_server/index.mjs
+++ b/common/frontend_server/index.mjs
@@ -56,6 +56,9 @@ export default async function(opts) {
   appZ.get('/healthz', ((req, res) => {
     res.end();
   }));
+  appZ.get('/_/healthz', ((req, res) => {
+    res.end();
+  }));
 
   const app = express();
   app.use(function(req, res, next) {
@@ -66,7 +69,7 @@ export default async function(opts) {
       next();
     }
   });
-  const prod = process.env.NODE_ENV === 'production';
+  const prod = process.env.NODE_ENV !== 'production';
 
   const port = prod ? (process.env.PORT || 8086) : opts.port;
 

--- a/common/frontend_server/index.mjs
+++ b/common/frontend_server/index.mjs
@@ -69,7 +69,7 @@ export default async function(opts) {
       next();
     }
   });
-  const prod = process.env.NODE_ENV !== 'production';
+  const prod = process.env.NODE_ENV === 'production';
 
   const port = prod ? (process.env.PORT || 8086) : opts.port;
 

--- a/common/frontend_server/upstream.mjs
+++ b/common/frontend_server/upstream.mjs
@@ -34,6 +34,9 @@ import os from 'os';
 
 export function svcName(svc, protocol) {
   let env = process.env['BYC_ENV'];
+  if (!env) {
+    env = 'dev';
+  }
   return `${svc}-${protocol}-${env}-service`;
 }
 
@@ -42,6 +45,10 @@ export function svcNameHttp(svc) {
 }
 
 export function endpoint(generatedServiceName, ns, port) {
+  const forceNs = process.env['BYC_FORCE_NS'];
+  if (forceNs) {
+    ns = forceNs;
+  }
   return `${generatedServiceName}.${ns}.svc.cluster.local${port}`;
 }
 

--- a/common/frontend_server/upstream.mjs
+++ b/common/frontend_server/upstream.mjs
@@ -32,6 +32,15 @@
 
 import os from 'os';
 
+export function envOverridable(svcName, protocol, x) {
+  const envName = `${svcName}_${protocol}_ENDPOINT_OVERRIDE`.toUpperCase();
+  const envValue = process.env[envName];
+  if (envValue) {
+    return envValue;
+  }
+  return x();
+}
+
 export function svcName(svc, protocol) {
   let env = process.env['BYC_ENV'];
   if (!env) {

--- a/hydra/pkg/hydra/autosignup.mjs
+++ b/hydra/pkg/hydra/autosignup.mjs
@@ -33,20 +33,29 @@
 // noinspection JSUnresolvedFunction
 // noinspection ES6PreferShortImport
 
-import { svcNameHttp, endpointHttp, NS } from '../../../common/frontend_server/upstream.mjs';
+import {
+  svcNameHttp,
+  endpointHttp,
+  NS,
+  envOverridable
+} from '../../../common/frontend_server/upstream.mjs';
 import pkg from '@ory/hydra-client';
 import os from 'os';
 
 const { Configuration, PublicApi, AdminApi } = pkg;
 
 export function hydraPublicUrl() {
-  const svc = svcNameHttp('hydra-public');
-  return endpointHttp(svc, NS('hydra-public'), ':4444');
+  return envOverridable('hydra_public', 'http', () => {
+    const svc = svcNameHttp('hydra-public');
+    return endpointHttp(svc, NS('hydra-public'), ':4444');
+  });
 }
 
 function hydraAdminUrl() {
-  const svc = svcNameHttp('hydra-admin');
-  return endpointHttp(svc, NS('hydra-admin'), ':4445');
+  return envOverridable('hydra_admin', 'http', () => {
+    const svc = svcNameHttp('hydra-admin');
+    return endpointHttp(svc, NS('hydra-admin'), ':4445');
+  });
 }
 
 const hydraAdmin = new AdminApi(

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@babel/preset-typescript": "^7.10.4",
     "@bazel/buildifier": "^5.1.0",
     "@bazel/hide-bazel-files": "^1.7.0",
-    "@bazel/typescript": "^5.5.2",
+    "@bazel/typescript": "^3.7.0",
     "@emotion/react": "^11.8.1",
     "@emotion/styled": "^11.8.1",
     "@heroicons/react": "^1.0.1",

--- a/peridot/builder/v1/workflow/infrastructure.go
+++ b/peridot/builder/v1/workflow/infrastructure.go
@@ -579,6 +579,10 @@ func (c *Controller) CreateK8sPodActivity(ctx context.Context, req *ProvisionWor
 							Value: imageArch,
 						},
 						{
+							Name:  "TEMPORAL_NAMESPACE",
+							Value: viper.GetString("temporal.namespace"),
+						},
+						{
 							Name:  "KEYKEEPER_GRPC_ENDPOINT_OVERRIDE",
 							Value: os.Getenv("KEYKEEPER_GRPC_ENDPOINT_OVERRIDE"),
 						},

--- a/peridot/yumrepofs/v1/blob.go
+++ b/peridot/yumrepofs/v1/blob.go
@@ -62,6 +62,9 @@ func (s *Server) GetBlob(ctx context.Context, req *yumrepofspb.GetBlobRequest) (
 	if err := req.ValidateAll(); err != nil {
 		return nil, err
 	}
+	if req.Arch == "i386" {
+		req.Arch = "i686"
+	}
 
 	if strings.HasSuffix(req.Blob, ".sqlite.gz") {
 		s3Req, _ := s.s3.GetObjectRequest(&s3.GetObjectInput{

--- a/peridot/yumrepofs/v1/metadata.go
+++ b/peridot/yumrepofs/v1/metadata.go
@@ -44,6 +44,9 @@ func (s *Server) GetRepoMd(_ context.Context, req *yumrepofspb.GetRepoMdRequest)
 	if err := req.ValidateAll(); err != nil {
 		return nil, err
 	}
+	if req.Arch == "i386" {
+		req.Arch = "i686"
+	}
 
 	latestRevision, err := s.db.GetLatestActiveRepositoryRevisionByProjectIdAndNameAndArch(req.ProjectId, req.RepoName, req.Arch)
 	if err != nil {
@@ -65,6 +68,9 @@ func (s *Server) GetRepoMd(_ context.Context, req *yumrepofspb.GetRepoMdRequest)
 func (s *Server) GetRepoMdSignature(_ context.Context, req *yumrepofspb.GetRepoMdRequest) (*httpbody.HttpBody, error) {
 	if err := req.ValidateAll(); err != nil {
 		return nil, err
+	}
+	if req.Arch == "i386" {
+		req.Arch = "i686"
 	}
 
 	latestRevision, err := s.db.GetLatestActiveRepositoryRevisionByProjectIdAndNameAndArch(req.ProjectId, req.RepoName, req.Arch)
@@ -88,6 +94,9 @@ func (s *Server) GetPublicKey(_ context.Context, req *yumrepofspb.GetPublicKeyRe
 	if err := req.ValidateAll(); err != nil {
 		return nil, err
 	}
+	if req.Arch == "i386" {
+		req.Arch = "i686"
+	}
 
 	key, err := s.db.GetDefaultKeyForProject(req.ProjectId)
 	if err != nil {
@@ -103,6 +112,9 @@ func (s *Server) GetPublicKey(_ context.Context, req *yumrepofspb.GetPublicKeyRe
 func (s *Server) GetUrlMappings(_ context.Context, req *yumrepofspb.GetUrlMappingsRequest) (*yumrepofspb.GetUrlMappingsResponse, error) {
 	if err := req.ValidateAll(); err != nil {
 		return nil, err
+	}
+	if req.Arch == "i386" {
+		req.Arch = "i686"
 	}
 
 	latestRevision, err := s.db.GetLatestActiveRepositoryRevisionByProjectIdAndNameAndArch(req.ProjectId, req.RepoName, req.Arch)

--- a/peridot/yumrepofs/v1/rpm.go
+++ b/peridot/yumrepofs/v1/rpm.go
@@ -51,6 +51,9 @@ func (s *Server) GetRpm(ctx context.Context, req *yumrepofspb.GetRpmRequest) (*y
 	if err := req.ValidateAll(); err != nil {
 		return nil, err
 	}
+	if req.Arch == "i386" {
+		req.Arch = "i686"
+	}
 
 	fileName := fmt.Sprintf("%s/%s.rpm", req.ParentTaskId, strings.TrimSuffix(req.FileName, ".rpm"))
 	if len(req.ParentTaskId) == 1 {

--- a/rules_byc/internal/container/container.bzl
+++ b/rules_byc/internal/container/container.bzl
@@ -1,5 +1,5 @@
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_push", "container_layer")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_layer", "container_push")
 load("@io_bazel_rules_docker//nodejs:image.bzl", "nodejs_image")
 
 REGISTRY_VARIANT = "aws"
@@ -63,10 +63,10 @@ def container(image_name, files, tars_to_layer = [], base = "//bases/bazel/go", 
 
     if len(server_files) > 0:
         nodejs_image(
-            name = "%s_image_node" %image_name,
+            name = "%s_image_node" % image_name,
             entry_point = server_entrypoint,
             data = server_files,
-            base = ":%s_image" % image_name
+            base = ":%s_image" % image_name,
         )
 
     container_push(
@@ -88,4 +88,3 @@ def container(image_name, files, tars_to_layer = [], base = "//bases/bazel/go", 
         }) if should_use_aws_format and not disable_conditional else tag,
         visibility = ["//visibility:public"],
     )
-

--- a/servicecatalog/common.go
+++ b/servicecatalog/common.go
@@ -50,6 +50,9 @@ func SvcNameGrpc(svc string) string {
 }
 
 func Endpoint(svcName string, ns string, port string) string {
+	if forceNs := os.Getenv("BYC_FORCE_NS"); forceNs != "" {
+		ns = forceNs
+	}
 	return fmt.Sprintf("%s.%s.svc.cluster.local%s", svcName, ns, port)
 }
 

--- a/servicecatalog/hydra.go
+++ b/servicecatalog/hydra.go
@@ -31,11 +31,15 @@
 package servicecatalog
 
 func HydraPublic() string {
-	svcName := SvcNameHttp("hydra-public")
-	return EndpointHttp(svcName, NS("hydra-public")) + ":4444"
+	return envOverridable("hydra_public", "http", func() string {
+		svcName := SvcNameHttp("hydra-public")
+		return EndpointHttp(svcName, NS("hydra-public")) + ":4444"
+	})
 }
 
 func HydraAdmin() string {
-	svcName := SvcNameHttp("hydra-admin")
-	return EndpointHttp(svcName, NS("hydra-admin")) + ":4445"
+	return envOverridable("hydra_admin", "http", func() string {
+		svcName := SvcNameHttp("hydra-admin")
+		return EndpointHttp(svcName, NS("hydra-admin")) + ":4445"
+	})
 }

--- a/servicecatalog/spicedb.go
+++ b/servicecatalog/spicedb.go
@@ -37,8 +37,10 @@ import (
 )
 
 func SpiceDB() string {
-	svcName := SvcNameGrpc("spicedb")
-	return Endpoint(svcName, NS("spicedb"), ":50051")
+	return envOverridable("spicedb", "grpc", func() string {
+		svcName := SvcNameGrpc("spicedb")
+		return Endpoint(svcName, NS("spicedb"), ":50051")
+	})
 }
 
 func SpiceDBCredentials() []grpc.DialOption {

--- a/temporalutils/BUILD.bazel
+++ b/temporalutils/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//vendor/github.com/sirupsen/logrus",
         "//vendor/github.com/spf13/pflag",
         "//vendor/github.com/spf13/viper",
+        "//vendor/go.temporal.io/api/workflowservice/v1:workflowservice",
         "//vendor/go.temporal.io/sdk/client",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//credentials",

--- a/temporalutils/client.go
+++ b/temporalutils/client.go
@@ -31,14 +31,18 @@
 package temporalutils
 
 import (
+	"context"
 	"crypto/tls"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/client"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"os"
 	"strings"
+	"time"
 )
 
 func AddFlags(pflags *pflag.FlagSet) {
@@ -65,6 +69,32 @@ func NewClient(opts client.Options) (client.Client, error) {
 	logrus.Infof("Using Temporal instance at %s", temporalHostPort)
 
 	opts.HostPort = temporalHostPort
+
+	bycNs := os.Getenv("BYC_NS")
+	temporalNamespace := os.Getenv("TEMPORAL_NAMESPACE")
+	if temporalNamespace != "" {
+		bycNs = temporalNamespace
+	}
+	if opts.Namespace != "" {
+		bycNs = opts.Namespace
+	}
+	if bycNs == "" {
+		bycNs = "default"
+	}
+
+	nscl, err := client.NewNamespaceClient(opts)
+	if err != nil {
+		return nil, err
+	}
+	dur := 5 * 24 * time.Hour
+	err = nscl.Register(context.TODO(), &workflowservice.RegisterNamespaceRequest{
+		Namespace:                        bycNs,
+		WorkflowExecutionRetentionPeriod: &dur,
+	})
+	if err != nil && !strings.Contains(err.Error(), "Namespace already exists") {
+		return nil, err
+	}
+	opts.Namespace = bycNs
 
 	return client.NewClient(opts)
 }

--- a/temporalutils/client.go
+++ b/temporalutils/client.go
@@ -95,6 +95,7 @@ func NewClient(opts client.Options) (client.Client, error) {
 		return nil, err
 	}
 	opts.Namespace = bycNs
+	viper.Set("temporal.namespace", bycNs)
 
 	return client.NewClient(opts)
 }


### PR DESCRIPTION
* Format WORKSPACE
* Re-add /_/healthz (removing it breaks current workflow)
* Add support for frontends to declare required email suffixes
* Make multiple upstream services env configurable
* Temporal namespace can now be customized
* Temporal namespace is now created if not found
* Yumrepofs now translates i386 to i686
* Various formatting changes
* Downgrade @bazel/typescript to match rules_nodejs