### PR TITLE
Use default namespace if not specified for Temporal in non-Helm mode

### DIFF
--- a/ci/temporal.jsonnet
+++ b/ci/temporal.jsonnet
@@ -2,8 +2,14 @@ local utils = import 'ci/utils.jsonnet';
 
 {
   hostport: if utils.local_image then 'temporal-frontend.default.svc.cluster.local:7233' else 'workflow-temporal-frontend.workflow.svc.cluster.local:7233',
-  kube_env(prefix): {
-    name: '%s_TEMPORAL_HOSTPORT' % prefix,
-    value: $.hostport,
-  }
+  kube_env(prefix): [
+    {
+      name: '%s_TEMPORAL_HOSTPORT' % prefix,
+      value: $.hostport,
+    }
+    {
+      name: 'TEMPORAL_NAMESPACE',
+      value: if utils.helm_mode then '{{ .Values.temporalNamespace | default !"!" }}' else 'default',
+    },
+  ],
 }

--- a/ci/utils.jsonnet
+++ b/ci/utils.jsonnet
@@ -7,4 +7,5 @@ local localImage = if localEnvironment == "1" then true else false;
 {
   local_image: localImage,
   docker_hub_image(name): "%s/%s" % [ociRegistryDocker, name],
+  helm_mode: false,
 }


### PR DESCRIPTION
Currently RESF deployment relies on Temporal using the `default` namespace