### PR TITLE
SOURCES dir should always be available in SRPM mode

### DIFF
--- a/peridot/builder/v1/workflow/srpm.go
+++ b/peridot/builder/v1/workflow/srpm.go
@@ -421,6 +421,10 @@ func (c *Controller) BuildSRPMActivity(ctx context.Context, upstreamPrefix strin
 	if err != nil {
 		return fmt.Errorf("could not write mock config: %v", err)
 	}
+	// The SOURCES dir should always be available. Some packages don't have that
+	// and Mock complains. Loudly. About that
+	_ = os.MkdirAll(filepath.Join(cloneDir, "SOURCES"), 0644)
+
 	args := []string{
 		"mock",
 		"--isolation=simple",


### PR DESCRIPTION
We switched to Mock SRPMs really late, and apparently Mock fatally fails if the sources dir is not available. We were not hit by this until now, but this PR should fix it.

Example failure: https://peridot.build.resf.org/55b17281-bc54-4929-8aca-a8a11d628738/tasks/b88f4e28-ee79-4fe0-bbf5-362463de657e