### PR TITLE
Upgrade srpmproc to v0.4.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/pelletier/go-toml v1.8.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.13.0
-	github.com/rocky-linux/srpmproc v0.4.1
+	github.com/rocky-linux/srpmproc v0.4.2
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -667,6 +667,8 @@ github.com/rocky-linux/srpmproc v0.3.16 h1:kxJEiQsZ0DcMhX0vY482n82XvjPiP2WifxI3N
 github.com/rocky-linux/srpmproc v0.3.16/go.mod h1:vWZzxPTfxh4pmfr5Mw20FyrqyKsbGHzDwOlN+W5EMpw=
 github.com/rocky-linux/srpmproc v0.4.1 h1:qcq7bGLplKbu+dSKQ9VBwcTao3OqPNb6rdKz58MCFLA=
 github.com/rocky-linux/srpmproc v0.4.1/go.mod h1:x8Z2wqhV2JqRnYMhYz3thOQkfsSWjJkyX8DVGDPOb48=
+github.com/rocky-linux/srpmproc v0.4.2 h1:U8SnYPxYtJ2XIAnrcEvxx+PsHCi4uQsfIOIC754MKas=
+github.com/rocky-linux/srpmproc v0.4.2/go.mod h1:x8Z2wqhV2JqRnYMhYz3thOQkfsSWjJkyX8DVGDPOb48=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/vendor/github.com/rocky-linux/srpmproc/modulemd/modulemd.go
+++ b/vendor/github.com/rocky-linux/srpmproc/modulemd/modulemd.go
@@ -22,6 +22,7 @@ package modulemd
 
 import (
 	"fmt"
+
 	"github.com/go-git/go-billy/v5"
 	"gopkg.in/yaml.v3"
 )

--- a/vendor/github.com/rocky-linux/srpmproc/pkg/blob/file/file.go
+++ b/vendor/github.com/rocky-linux/srpmproc/pkg/blob/file/file.go
@@ -38,7 +38,7 @@ func New(path string) *File {
 }
 
 func (f *File) Write(path string, content []byte) error {
-	w, err := os.OpenFile(filepath.Join(f.path, path), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0644)
+	w, err := os.OpenFile(filepath.Join(f.path, path), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 	if err != nil {
 		return fmt.Errorf("could not open file: %v", err)
 	}
@@ -57,7 +57,7 @@ func (f *File) Write(path string, content []byte) error {
 }
 
 func (f *File) Read(path string) ([]byte, error) {
-	r, err := os.OpenFile(filepath.Join(f.path, path), os.O_RDONLY, 0644)
+	r, err := os.OpenFile(filepath.Join(f.path, path), os.O_RDONLY, 0o644)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil

--- a/vendor/github.com/rocky-linux/srpmproc/pkg/blob/gcs/gcs.go
+++ b/vendor/github.com/rocky-linux/srpmproc/pkg/blob/gcs/gcs.go
@@ -21,10 +21,11 @@
 package gcs
 
 import (
-	"cloud.google.com/go/storage"
 	"context"
 	"fmt"
 	"io/ioutil"
+
+	"cloud.google.com/go/storage"
 )
 
 type GCS struct {

--- a/vendor/github.com/rocky-linux/srpmproc/pkg/blob/s3/s3.go
+++ b/vendor/github.com/rocky-linux/srpmproc/pkg/blob/s3/s3.go
@@ -22,6 +22,8 @@ package s3
 
 import (
 	"bytes"
+	"io/ioutil"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -29,7 +31,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/spf13/viper"
-	"io/ioutil"
 )
 
 type S3 struct {

--- a/vendor/github.com/rocky-linux/srpmproc/pkg/data/import.go
+++ b/vendor/github.com/rocky-linux/srpmproc/pkg/data/import.go
@@ -21,8 +21,9 @@
 package data
 
 import (
-	"github.com/go-git/go-git/v5"
 	"hash"
+
+	"github.com/go-git/go-git/v5"
 )
 
 type ImportMode interface {

--- a/vendor/github.com/rocky-linux/srpmproc/pkg/data/process.go
+++ b/vendor/github.com/rocky-linux/srpmproc/pkg/data/process.go
@@ -21,10 +21,11 @@
 package data
 
 import (
+	"log"
+
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/rocky-linux/srpmproc/pkg/blob"
-	"log"
 )
 
 type FsCreatorFunc func(branch string) (billy.Filesystem, error)

--- a/vendor/github.com/rocky-linux/srpmproc/pkg/data/utils.go
+++ b/vendor/github.com/rocky-linux/srpmproc/pkg/data/utils.go
@@ -27,11 +27,12 @@ import (
 	"crypto/sha512"
 	"encoding/hex"
 	"fmt"
-	"github.com/go-git/go-billy/v5"
 	"hash"
 	"io"
 	"os"
 	"path/filepath"
+
+	"github.com/go-git/go-billy/v5"
 )
 
 func CopyFromFs(from billy.Filesystem, to billy.Filesystem, path string) error {
@@ -44,7 +45,7 @@ func CopyFromFs(from billy.Filesystem, to billy.Filesystem, path string) error {
 		fullPath := filepath.Join(path, fi.Name())
 
 		if fi.IsDir() {
-			_ = to.MkdirAll(fullPath, 0755)
+			_ = to.MkdirAll(fullPath, 0o755)
 			err := CopyFromFs(from, to, fullPath)
 			if err != nil {
 				return err

--- a/vendor/github.com/rocky-linux/srpmproc/pkg/directives/add.go
+++ b/vendor/github.com/rocky-linux/srpmproc/pkg/directives/add.go
@@ -50,7 +50,7 @@ func add(cfg *srpmprocpb.Cfg, pd *data.ProcessData, md *data.ModeData, patchTree
 		case *srpmprocpb.Add_File:
 			filePath = checkAddPrefix(eitherString(filepath.Base(addType.File), add.Name))
 
-			fPatch, err := patchTree.Filesystem.OpenFile(addType.File, os.O_RDONLY, 0644)
+			fPatch, err := patchTree.Filesystem.OpenFile(addType.File, os.O_RDONLY, 0o644)
 			if err != nil {
 				return errors.New(fmt.Sprintf("COULD_NOT_OPEN_FROM:%s", addType.File))
 			}
@@ -80,7 +80,7 @@ func add(cfg *srpmprocpb.Cfg, pd *data.ProcessData, md *data.ModeData, patchTree
 			break
 		}
 
-		f, err := pushTree.Filesystem.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+		f, err := pushTree.Filesystem.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
 		if err != nil {
 			return errors.New(fmt.Sprintf("COULD_NOT_OPEN_DESTINATION:%s", filePath))
 		}

--- a/vendor/github.com/rocky-linux/srpmproc/pkg/directives/lookaside.go
+++ b/vendor/github.com/rocky-linux/srpmproc/pkg/directives/lookaside.go
@@ -128,7 +128,7 @@ func lookaside(cfg *srpmprocpb.Cfg, _ *data.ProcessData, md *data.ModeData, patc
 			}
 
 			path := filepath.Join("SOURCES", fmt.Sprintf("%s.tar.gz", directive.ArchiveName))
-			pushF, err := pushTree.Filesystem.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0644)
+			pushF, err := pushTree.Filesystem.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 			if err != nil {
 				return errors.New(fmt.Sprintf("COULD_NOT_CREATE_TAR_FILE:%s", path))
 			}

--- a/vendor/github.com/rocky-linux/srpmproc/pkg/directives/patch.go
+++ b/vendor/github.com/rocky-linux/srpmproc/pkg/directives/patch.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+
 	"github.com/bluekeyes/go-gitdiff/gitdiff"
 	"github.com/go-git/go-git/v5"
 	srpmprocpb "github.com/rocky-linux/srpmproc/pb"

--- a/vendor/github.com/rocky-linux/srpmproc/pkg/directives/replace.go
+++ b/vendor/github.com/rocky-linux/srpmproc/pkg/directives/replace.go
@@ -51,7 +51,7 @@ func replace(cfg *srpmprocpb.Cfg, pd *data.ProcessData, _ *data.ModeData, patchT
 
 		switch replacing := replace.Replacing.(type) {
 		case *srpmprocpb.Replace_WithFile:
-			fPatch, err := patchTree.Filesystem.OpenFile(replacing.WithFile, os.O_RDONLY, 0644)
+			fPatch, err := patchTree.Filesystem.OpenFile(replacing.WithFile, os.O_RDONLY, 0o644)
 			if err != nil {
 				return errors.New(fmt.Sprintf("COULD_NOT_OPEN_REPLACING:%s", replacing.WithFile))
 			}

--- a/vendor/github.com/rocky-linux/srpmproc/pkg/directives/spec_change.go
+++ b/vendor/github.com/rocky-linux/srpmproc/pkg/directives/spec_change.go
@@ -41,9 +41,7 @@ const (
 	sectionChangelog = "%changelog"
 )
 
-var (
-	sections = []string{"%description", "%prep", "%build", "%install", "%files", "%changelog"}
-)
+var sections = []string{"%description", "%prep", "%build", "%install", "%files", "%changelog"}
 
 type sourcePatchOperationInLoopRequest struct {
 	cfg           *srpmprocpb.Cfg
@@ -212,7 +210,7 @@ func specChange(cfg *srpmprocpb.Cfg, pd *data.ProcessData, md *data.ModeData, _ 
 		return errors.New("COULD_NOT_STAT_SPEC_FILE")
 	}
 
-	specFile, err := pushTree.Filesystem.OpenFile(filePath, os.O_RDONLY, 0644)
+	specFile, err := pushTree.Filesystem.OpenFile(filePath, os.O_RDONLY, 0o644)
 	if err != nil {
 		return errors.New("COULD_NOT_READ_SPEC_FILE")
 	}

--- a/vendor/github.com/rocky-linux/srpmproc/pkg/misc/regex.go
+++ b/vendor/github.com/rocky-linux/srpmproc/pkg/misc/regex.go
@@ -2,10 +2,11 @@ package misc
 
 import (
 	"fmt"
-	"github.com/rocky-linux/srpmproc/pkg/data"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/rocky-linux/srpmproc/pkg/data"
 )
 
 func GetTagImportRegex(pd *data.ProcessData) *regexp.Regexp {
@@ -37,7 +38,6 @@ func GetTagImportRegex(pd *data.ProcessData) *regexp.Regexp {
 // if we are ok with importing that reference.  We are looking for the traditional <prefix><version><suffix> pattern, like "c9s", and also the
 // modular "stream-<NAME>-<VERSION>-rhel-<VERSION> branch pattern as well
 func TaglessRefOk(tag string, pd *data.ProcessData) bool {
-
 	// First case is very easy: if we are "refs/heads/<prefix><version><suffix>" , then this is def. a branch we should import
 	if strings.HasPrefix(tag, fmt.Sprintf("refs/heads/%s%d%s", pd.ImportBranchPrefix, pd.Version, pd.BranchSuffix)) {
 		return true

--- a/vendor/github.com/rocky-linux/srpmproc/pkg/modes/git.go
+++ b/vendor/github.com/rocky-linux/srpmproc/pkg/modes/git.go
@@ -22,14 +22,15 @@ package modes
 
 import (
 	"fmt"
-	"github.com/go-git/go-git/v5/plumbing/transport"
-	"github.com/rocky-linux/srpmproc/pkg/misc"
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/rocky-linux/srpmproc/pkg/misc"
 
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-git/v5"
@@ -146,7 +147,6 @@ func (g *GitMode) RetrieveSource(pd *data.ProcessData) (*data.ModeData, error) {
 	}
 
 	tagIter, err := repo.TagObjects()
-
 	if err != nil {
 		return nil, fmt.Errorf("could not get tag objects: %v", err)
 	}
@@ -221,7 +221,6 @@ func (g *GitMode) RetrieveSource(pd *data.ProcessData) (*data.ModeData, error) {
 }
 
 func (g *GitMode) WriteSource(pd *data.ProcessData, md *data.ModeData) error {
-
 	remote, err := md.Repo.Remote("upstream")
 
 	if err != nil && !pd.TaglessMode {

--- a/vendor/github.com/rocky-linux/srpmproc/pkg/rpmutils/regex.go
+++ b/vendor/github.com/rocky-linux/srpmproc/pkg/rpmutils/regex.go
@@ -2,10 +2,5 @@ package rpmutils
 
 import "regexp"
 
-var (
-	Nvr        = regexp.MustCompile("^(\\S+)-([\\w~%.+]+)-(\\w+(?:\\.[\\w+]+)+?)(?:\\.(\\w+))?(?:\\.rpm)?$")
-	epoch      = regexp.MustCompile("(\\d+):")
-	module     = regexp.MustCompile("^(.+)-(.+)-([0-9]{19})\\.((?:.+){8})$")
-	dist       = regexp.MustCompile("(\\.el\\d(?:_\\d|))")
-	moduleDist = regexp.MustCompile("\\.module.+$")
-)
+// Nvr is a regular expression that matches a NVR.
+var Nvr = regexp.MustCompile("^(\\S+)-([\\w~%.+]+)-(\\w+(?:\\.[\\w+]+)+?)(?:\\.rpm)?$")

--- a/vendor/github.com/rocky-linux/srpmproc/pkg/srpmproc/fetch.go
+++ b/vendor/github.com/rocky-linux/srpmproc/pkg/srpmproc/fetch.go
@@ -3,15 +3,16 @@ package srpmproc
 import (
 	"errors"
 	"fmt"
-	"github.com/go-git/go-billy/v5"
-	"github.com/rocky-linux/srpmproc/pkg/blob"
-	"github.com/rocky-linux/srpmproc/pkg/data"
 	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"path/filepath"
 	"strings"
+
+	"github.com/go-git/go-billy/v5"
+	"github.com/rocky-linux/srpmproc/pkg/blob"
+	"github.com/rocky-linux/srpmproc/pkg/data"
 )
 
 func Fetch(logger io.Writer, cdnUrl string, dir string, fs billy.Filesystem, storage blob.Storage) error {
@@ -101,7 +102,7 @@ func Fetch(logger io.Writer, cdnUrl string, dir string, fs billy.Filesystem, sto
 			return fmt.Errorf("checksum in metadata does not match dist-git file")
 		}
 
-		err = fs.MkdirAll(filepath.Join(dir, filepath.Dir(path)), 0755)
+		err = fs.MkdirAll(filepath.Join(dir, filepath.Dir(path)), 0o755)
 		if err != nil {
 			return fmt.Errorf("could not create all directories")
 		}

--- a/vendor/github.com/rocky-linux/srpmproc/pkg/srpmproc/patch.go
+++ b/vendor/github.com/rocky-linux/srpmproc/pkg/srpmproc/patch.go
@@ -23,14 +23,15 @@ package srpmproc
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/go-git/go-git/v5/plumbing/transport"
-	"github.com/rocky-linux/srpmproc/pkg/misc"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/rocky-linux/srpmproc/pkg/misc"
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/memfs"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -453,7 +453,7 @@ github.com/prometheus/procfs/internal/util
 github.com/rivo/uniseg
 # github.com/robfig/cron v1.2.0
 github.com/robfig/cron
-# github.com/rocky-linux/srpmproc v0.4.1
+# github.com/rocky-linux/srpmproc v0.4.2
 ## explicit
 github.com/rocky-linux/srpmproc/modulemd
 github.com/rocky-linux/srpmproc/pb


### PR DESCRIPTION
Earlier srpmproc versions have a bug with VRE matching. The regex used to match the NVR was actually formed to match NVRA. This is generally not harmful, but NVRs that has an extra dot something in Release can throw off this regex into thinking that the dist is actually the arch.

Fixes #27 