### PR TITLE
Peridot: Fix MakeActiveInRepo - Only set for current project

### DIFF
--- a/peridot/builder/v1/workflow/yumrepofs.go
+++ b/peridot/builder/v1/workflow/yumrepofs.go
@@ -1477,7 +1477,7 @@ func (c *Controller) makeRepoChanges(tx peridotdb.Access, req *UpdateRepoRequest
 	}
 
 	if !req.DisableSetActive {
-		err = tx.MakeActiveInRepoForPackageVersion(build.PackageVersionId, build.PackageId)
+		err = tx.MakeActiveInRepoForPackageVersion(build.PackageVersionId, build.PackageId, build.ProjectId)
 		if err != nil {
 			c.log.Errorf("failed to set active build for project %s, package %s: %s", project.ID.String(), packageName, err)
 			return nil, err

--- a/peridot/db/db.go
+++ b/peridot/db/db.go
@@ -93,7 +93,7 @@ type Access interface {
 	AttachPackageVersion(projectId string, packageId string, packageVersionId string, active bool) error
 	GetProjectPackageVersionFromPackageVersionId(packageVersionId string, projectId string) (string, error)
 	DeactivateProjectPackageVersionByPackageIdAndProjectId(packageId string, projectId string) error
-	MakeActiveInRepoForPackageVersion(packageVersionId string, packageId string) error
+	MakeActiveInRepoForPackageVersion(packageVersionId string, packageId string, projectId string) error
 	CreatePackage(name string, packageType peridotpb.PackageType) (*models.Package, error)
 	AddPackageToProject(projectId string, packageId string, packageTypeOverride peridotpb.PackageType) error
 	GetPackageID(name string) (string, error)

--- a/peridot/db/psql/package.go
+++ b/peridot/db/psql/package.go
@@ -242,18 +242,18 @@ func (a *Access) DeactivateProjectPackageVersionByPackageIdAndProjectId(packageI
 	return err
 }
 
-func (a *Access) MakeActiveInRepoForPackageVersion(packageVersionId string, packageId string) error {
+func (a *Access) MakeActiveInRepoForPackageVersion(packageVersionId string, packageId string, projectId string) error {
 	tx, err := a.Begin()
 	if err != nil {
 		return err
 	}
 
-	_, err = tx.Exec("update project_package_versions set active_in_repo = false where package_id = $1", packageId)
+	_, err = tx.Exec("update project_package_versions set active_in_repo = false where package_id = $1 and project_id = $2", packageId, projectId)
 	if err != nil {
 		return err
 	}
 
-	_, err = tx.Exec("update project_package_versions set active_in_repo = true where package_version_id = $1", packageVersionId)
+	_, err = tx.Exec("update project_package_versions set active_in_repo = true where package_version_id = $1 and project_id = $2", packageVersionId, projectId)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Current behavior sets active package version in repo for all projects even though yumrepofs is only updating for a specific project. This fixes it by only setting active package version in repo for that specific version in that specific project.