### PR TITLE
bump golang to 1.18.9 for several CVEs

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -54,7 +54,7 @@ go_rules_dependencies()
 
 go_register_toolchains(
     nogo = "@peridot//:nogo",
-    version = "1.18.3",
+    version = "1.18.9",
 )
 
 go_repository(


### PR DESCRIPTION
* net/http (CVE-2022-41717, CVE-2022-41720)
* os (CVE-2022-41720)

Signed-off-by: Neil Hanlon <neil@rockylinux.org>