### PR TITLE
Bump go to 1.18.10

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -54,7 +54,7 @@ go_rules_dependencies()
 
 go_register_toolchains(
     nogo = "@peridot//:nogo",
-    version = "1.18.9",
+    version = "1.18.10",
 )
 
 go_repository(


### PR DESCRIPTION
Resolve https://github.com/rocky-linux/peridot/security/dependabot/33 and https://github.com/rocky-linux/peridot/security/dependabot/32