### PR TITLE
fix(regression): respect modules enabled by ModuleMd during module builds

### DIFF
--- a/peridot/builder/v1/workflow/arch.go
+++ b/peridot/builder/v1/workflow/arch.go
@@ -687,8 +687,15 @@ func (c *Controller) BuildArchActivity(ctx context.Context, projectId string, pa
 		c.log.Infof("no extra options to process for package")
 	}
 
-	extraOptions.DisabledModules = disableModules
-	extraOptions.Modules = enableModules
+	if extraOptions.DisabledModules == nil {
+		extraOptions.DisabledModules = []string{}
+	}
+	extraOptions.DisabledModules = append(extraOptions.DisabledModules, disableModules...)
+
+	if extraOptions.Modules == nil {
+		extraOptions.Modules = []string{}
+	}
+	extraOptions.Modules = append(extraOptions.Modules, enableModules...)
 
 	hostArch := os.Getenv("REAL_BUILD_ARCH")
 	err = c.writeMockConfig(&project, packageVersion, extraOptions, arch, hostArch, pkgGroup)

--- a/peridot/builder/v1/workflow/srpm.go
+++ b/peridot/builder/v1/workflow/srpm.go
@@ -425,8 +425,15 @@ func (c *Controller) BuildSRPMActivity(ctx context.Context, upstreamPrefix strin
 		c.log.Infof("no extra options to process for package")
 	}
 
-	extraOptions.DisabledModules = disableModules
-	extraOptions.Modules = enableModules
+	if extraOptions.DisabledModules == nil {
+		extraOptions.DisabledModules = []string{}
+	}
+	extraOptions.DisabledModules = append(extraOptions.DisabledModules, disableModules...)
+
+	if extraOptions.Modules == nil {
+		extraOptions.Modules = []string{}
+	}
+	extraOptions.Modules = append(extraOptions.Modules, enableModules...)
 
 	hostArch := os.Getenv("REAL_BUILD_ARCH")
 	extraOptions.EnableNetworking = true


### PR DESCRIPTION
#78/#79 added support for setting normal-type Packages' enabled and disabled modules, and incidentally overwrote any modules being passed from _actual_ module builds which are required for building.

We noticed this when building Maven, as it requires javapackages-tools, but was not requesting them.