### PR TITLE
Remove file form field from CatalogSync

### DIFF
--- a/peridot/ui/src/components/forms/SyncForm.tsx
+++ b/peridot/ui/src/components/forms/SyncForm.tsx
@@ -122,14 +122,6 @@ export const SyncForm = (props: SyncFormProps) => {
               label="Branch"
               name="branch"
             />
-            <TextField
-              sx={{ display: 'flex' }}
-              required
-              size="small"
-              label="File"
-              name="file"
-              defaultValue="catalog.cfg"
-            />
           </div>
         </div>
         <div className="w-full flex justify-end mt-4">


### PR DESCRIPTION
This endpoint doesn't ask for a file, so this is superfluous and, therefore, confusing.. me. It's confusing me.