### PR TITLE
Increase HeartbeatTimeout for BuildArchActivity

### DIFF
--- a/peridot/builder/v1/workflow/build.go
+++ b/peridot/builder/v1/workflow/build.go
@@ -681,7 +681,7 @@ func (c *Controller) BuildWorkflow(ctx workflow.Context, req *peridotpb.SubmitBu
 			archCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 				ScheduleToStartTimeout: 12 * time.Hour,
 				StartToCloseTimeout:    48 * time.Hour,
-				HeartbeatTimeout:       2 * time.Hour,
+				HeartbeatTimeout:       12 * time.Hour,
 				TaskQueue:              archTaskQueue,
 				RetryPolicy: &temporal.RetryPolicy{
 					MaximumAttempts: 1,


### PR DESCRIPTION
Currently the Rust builds fails, most likely due to a lock that happens with aarch64. Either the heartbeat tick dies early and timeout happens right before success or something else makes heartbeats not work at all. Best solution for now is to just increase timeout.