### PR TITLE
fix: sync hydra deployment to ^2.0

### DIFF
--- a/hydra/deploy/common.jsonnet
+++ b/hydra/deploy/common.jsonnet
@@ -9,7 +9,7 @@ local authn = if kubernetes.prod() then 'https://id.build.resf.org' else 'http:/
 
 {
   image: 'oryd/hydra',
-  tag: 'v1.11.7',
+  tag: 'v2.0.3',
   legacyDb: true,
   env: [
     {


### PR DESCRIPTION
UI was upgraded for hydra-client v2.0.2, but the chart deployment is still deploying an incompatible server version causing a deployment mismatch and failure to deploy the new peridot frontend