### PR TITLE
build RPM for peridot cli

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -63,6 +63,19 @@ load("//:repositories.bzl", "go_repositories")
 
 go_rules_dependencies()
 
+http_archive(
+    name = "rules_pkg",
+    urls = [
+        "https://github.com/bazelbuild/rules_pkg/releases/download/0.10.1/rules_pkg-0.10.1.tar.gz",
+    ],
+    sha256 = "d250924a2ecc5176808fc4c25d5cf5e9e79e6346d79d5ab1c493e289e722d1d0",
+)
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+rules_pkg_dependencies()
+
+load("@rules_pkg//toolchains/rpm:rpmbuild_configure.bzl", "find_system_rpmbuild")
+find_system_rpmbuild(name="rules_pkg_rpmbuild")
+
 go_register_toolchains(
     nogo = "@peridot//:nogo",
     version = "1.22.2",

--- a/peridot/cmd/v1/peridot/BUILD.bazel
+++ b/peridot/cmd/v1/peridot/BUILD.bazel
@@ -1,5 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
+load(
+    "@rules_pkg//pkg:mappings.bzl",
+    "pkg_attributes",
+    "pkg_files",
+)
+load("@rules_pkg//pkg:rpm.bzl", "pkg_rpm")
+
 go_library(
     name = "peridot_lib",
     srcs = [
@@ -20,6 +27,9 @@ go_library(
     data = [
         "//peridot/proto/v1:client_go",
     ],
+    x_defs = {
+        "Version": "{STABLE_BUILD_TAG}",
+    },
     importpath = "peridot.resf.org/peridot/cmd/v1/peridot",
     visibility = ["//visibility:private"],
     deps = [
@@ -36,4 +46,27 @@ go_binary(
     name = "peridot",
     embed = [":peridot_lib"],
     visibility = ["//visibility:public"],
+)
+
+pkg_files(
+  name = "peridot-files",
+  srcs = [":peridot"],
+  attributes = pkg_attributes(
+    user = "root",
+    group = "root",
+    mode = "0755",
+  ),
+  prefix = "/usr/bin"
+)
+
+pkg_rpm(
+    name = "peridot-cli",
+    srcs = [":peridot-files"],
+    license = "MIT",
+    summary = "Peridot Command Line Interface",
+    version = "0.2.0",
+    release = "0",
+    architecture = "x86_64",
+    description = "A command line interface to interact with the Peridot build system",
+    source_date_epoch = 0,
 )

--- a/peridot/cmd/v1/peridot/main.go
+++ b/peridot/cmd/v1/peridot/main.go
@@ -31,15 +31,19 @@
 package main
 
 import (
+	"log"
+	"strings"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"log"
-	"strings"
 )
 
+var Version = "[unknown]"
+
 var root = &cobra.Command{
-	Use: "peridot",
+	Use:     "peridot",
+	Version: Version,
 }
 
 func init() {


### PR DESCRIPTION
### TL;DR

This PR introduces Bazel's rules_pkg and creates an RPM package for the Peridot CLI.

### What changed?

- Added `rules_pkg` dependency to the `WORKSPACE`
- Modified `BUILD.bazel` to include `pkg_attributes`, `pkg_files`, and `pkg_rpm` rules
- Set version information in the Go code using Bazel build variables