### PR TITLE
Upgrade Go to 1.22.2 and fix ppc64le builds

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,10 +37,14 @@ protobuf_deps()
 
 http_archive(
     name = "io_bazel_rules_go",
-    integrity = "sha256-fHbWI2so/2laoozzX5XeMXqUcv0fsUrHl8m/aE8Js3w=",
+    patch_args = ["-p1"],
+    patches = [
+        "//patches:0001-Disable-ppc64-support-in-rules_go-as-it-breaks-match.patch",
+    ],
+    sha256 = "af47f30e9cbd70ae34e49866e201b3f77069abb111183f2c0297e7e74ba6bbc0",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.44.2/rules_go-v0.44.2.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.44.2/rules_go-v0.44.2.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.47.0/rules_go-v0.47.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.47.0/rules_go-v0.47.0.zip",
     ],
 )
 
@@ -61,7 +65,7 @@ go_rules_dependencies()
 
 go_register_toolchains(
     nogo = "@peridot//:nogo",
-    version = "1.20.5",
+    version = "1.22.2",
 )
 
 # gazelle:repository_macro repositories.bzl%go_repositories

--- a/patches/0001-Disable-ppc64-support-in-rules_go-as-it-breaks-match.patch
+++ b/patches/0001-Disable-ppc64-support-in-rules_go-as-it-breaks-match.patch
@@ -1,0 +1,25 @@
+From 68951b80d26227794abd394a7f8ac684b49f33ad Mon Sep 17 00:00:00 2001
+From: Mustafa Gezen <mustafa@rockylinux.org>
+Date: Thu, 25 Apr 2024 12:59:59 +0200
+Subject: [PATCH] Disable ppc64 support in rules_go, as it breaks matching for
+ ppc64le
+
+---
+ go/private/platforms.bzl | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/go/private/platforms.bzl b/go/private/platforms.bzl
+index 664f7aed..ef5319a4 100644
+--- a/go/private/platforms.bzl
++++ b/go/private/platforms.bzl
+@@ -30,7 +30,6 @@ BAZEL_GOARCH_CONSTRAINTS = {
+     "amd64": "@platforms//cpu:x86_64",
+     "arm": "@platforms//cpu:armv7",
+     "arm64": "@platforms//cpu:aarch64",
+-    "ppc64": "@platforms//cpu:ppc",
+     "ppc64le": "@platforms//cpu:ppc",
+     "s390x": "@platforms//cpu:s390x",
+ }
+-- 
+2.39.3 (Apple Git-146)
+


### PR DESCRIPTION
Go 1.22.2 fixes some CVEs so we should upgrade. This PR reverts support for "ppc64" in rules_go. It was a recent addition but breaks builds for ppc64le. @platforms recently added explicit ppc64le support so when rules_go switches to that we can remove this patch