### PR TITLE
Add support for V3 signature headers

### DIFF
--- a/peridot/builder/v1/workflow/yumrepofs.go
+++ b/peridot/builder/v1/workflow/yumrepofs.go
@@ -66,6 +66,7 @@ import (
 	yumrepofspb "peridot.resf.org/peridot/yumrepofs/pb"
 	"peridot.resf.org/utils"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -1400,6 +1401,9 @@ func (c *Controller) makeRepoChanges(tx peridotdb.Access, req *UpdateRepoRequest
 
 					pkgPrimary.Packages[0].Location.Href = fmt.Sprintf("Packages/%s", newObjectKey)
 					pkgPrimary.Packages[0].Checksum.Value = signedArtifact.HashSha256
+					if signedArtifact.SignedSize > 0 {
+						pkgPrimary.Packages[0].Size.Package = strconv.FormatInt(signedArtifact.SignedSize, 10)
+					}
 
 					for _, pkg := range pkgFilelists.Packages {
 						pkg.PkgId = signedArtifact.HashSha256

--- a/peridot/keykeeper/v1/sign.go
+++ b/peridot/keykeeper/v1/sign.go
@@ -246,9 +246,16 @@ func (s *Server) SignArtifactActivity(ctx context.Context, artifactId string, ke
 				return nil, fmt.Errorf("failed to create task artifact signature: %v", err)
 			}
 
+			// Get the size of the file
+			fi, err := f.Stat()
+			if err != nil {
+				return nil, err
+			}
+
 			return &keykeeperpb.SignedArtifact{
 				Path:       newObjectKey,
 				HashSha256: hash,
+				SignedSize: fi.Size(),
 			}, nil
 		}
 		verifySig := func() error {

--- a/peridot/proto/v1/keykeeper/keykeeper.proto
+++ b/peridot/proto/v1/keykeeper/keykeeper.proto
@@ -86,6 +86,7 @@ message ImportKeyResponse {}
 message SignedArtifact {
   string path = 1;
   string hash_sha256 = 2;
+  int64 signed_size = 3;
 }
 
 message SignArtifactsRequest {


### PR DESCRIPTION
Currently the signing process assumes that the "Package" size stays consistent post-build and post-sign. This is a small backwards-compatible change that properly sets a post-sign size in the metadata during sync.