### PR TITLE
feat: allow rpm import to skip upload OR import step

### DIFF
--- a/peridot/cmd/v1/peridot/BUILD.bazel
+++ b/peridot/cmd/v1/peridot/BUILD.bazel
@@ -64,7 +64,7 @@ pkg_rpm(
     srcs = [":peridot-files"],
     license = "MIT",
     summary = "Peridot Command Line Interface",
-    version = "0.2.0",
+    version = "0.2.1",
     release = "0",
     architecture = "x86_64",
     description = "A command line interface to interact with the Peridot build system",

--- a/peridot/cmd/v1/peridot/BUILD.bazel
+++ b/peridot/cmd/v1/peridot/BUILD.bazel
@@ -65,7 +65,7 @@ pkg_rpm(
     license = "MIT",
     summary = "Peridot Command Line Interface",
     version = "0.2.1",
-    release = "0",
+    release = "1",
     architecture = "x86_64",
     description = "A command line interface to interact with the Peridot build system",
     source_date_epoch = 0,


### PR DESCRIPTION
### TL;DR

Add options to `buildRpmImport` command for skipping upload or import steps, and update version to 0.2.1.

### What changed?

- New flags added: `--skip` / `-s` for skipping steps (either 'upload' or 'import').
- Updated `BUILD.bazel` with version bump to 0.2.1 and release to 1.
- Introduced SHA256 hashing for file integrity verification.
- Reorganized package imports and improved error handling
